### PR TITLE
[FIX] Better handle heartbeats to recover stale/broken connections

### DIFF
--- a/dark_rabbit/__manifest__.py
+++ b/dark_rabbit/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Dark Rabbit",
-    "version": "18.0.0.3.7",
+    "version": "18.0.0.3.8",
     "license": "LGPL-3",
     "summary": "Rabbit from Dark Side. Brings some dark magic to your messaging.",
     "category": "Technical Settings",

--- a/dark_rabbit/tools/dark_connection_base.py
+++ b/dark_rabbit/tools/dark_connection_base.py
@@ -3,6 +3,7 @@ import logging
 import pika
 
 DEFAULT_PROCESS_EVENTS_TIME_LIMIT = 0.2
+DEFAULT_PIKA_HEARTBEAT = 60
 
 _logger = logging.getLogger(__name__)
 
@@ -61,9 +62,15 @@ class DarkRabbitConnectionBase:
             # It seems that connection already established. No further work needed.
             return
 
-        self._connection = pika.BlockingConnection(
-            pika.URLParameters(self._config["connection_url"])
-        )
+        params = pika.URLParameters(self._config["connection_url"])
+        # heartbeat=None means "accept whatever the server proposes" —
+        # if the server is configured with heartbeat=0, detection is
+        # silently disabled. heartbeat=0 explicitly disables it too.
+        # In both cases enforce a minimum so dead TCP connections are
+        # always detected regardless of server configuration.
+        if not params.heartbeat:
+            params.heartbeat = DEFAULT_PIKA_HEARTBEAT
+        self._connection = pika.BlockingConnection(params)
         self._channel = self.connection.channel()
 
         # TODO: Move binding and declare to separate method,

--- a/dark_rabbit/tools/dark_connection_pool.py
+++ b/dark_rabbit/tools/dark_connection_pool.py
@@ -1,5 +1,7 @@
 import logging
 
+import pika.exceptions
+
 from .dark_connection_base import DEFAULT_PROCESS_EVENTS_TIME_LIMIT
 
 _logger = logging.getLogger(__name__)
@@ -22,8 +24,6 @@ class DarkConnectionPool:
         # Dict: {conn_id: DarkRabbitConnectionBase}
         self._registry = {}
         self._connection_factory = connection_factory
-
-        # TODO: Also, handle correctly heartbeats
         self._process_data_events_timelimit = process_data_events_timelimit
 
     @property
@@ -91,15 +91,21 @@ class DarkConnectionPool:
                 connection.process_data_events(
                     time_limit=self._process_data_events_timelimit
                 )
+            except pika.exceptions.AMQPHeartbeatTimeout:
+                _logger.error(
+                    "Heartbeat timeout on connection %s —"
+                    " TCP connection is dead, scheduling reload",
+                    connection.connection_id,
+                    exc_info=True,
+                )
+                connection.schedule_reload()
             except ValueError as e:
                 _logger.error(
-                    "Error while process events (conn_id=%s)",
+                    "Error while processing events (conn_id=%s)",
                     connection.connection_id,
                     exc_info=True,
                 )
                 if str(e) == "Timeout closed before call":
-                    # It seems that connection was closed, so in this case we
-                    # just schedule connection reload
                     connection.schedule_reload()
                     continue
                 raise


### PR DESCRIPTION
Use default 600s heartbeats. Thus if server do not provide another value, this value will be used.