### PR TITLE
[FIX] Do not depend counters on `event_ids`  and `outgoing_event_ids`

### DIFF
--- a/dark_rabbit/__manifest__.py
+++ b/dark_rabbit/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Dark Rabbit",
-    "version": "18.0.0.5.3",
+    "version": "18.0.0.5.4",
     "license": "LGPL-3",
     "summary": "Rabbit from Dark Side. Brings some dark magic to your messaging.",
     "category": "Technical Settings",

--- a/dark_rabbit/models/connection.py
+++ b/dark_rabbit/models/connection.py
@@ -79,7 +79,7 @@ class DarkRabbitConnection(models.Model):
         for rec in self:
             rec.exchange_count = mapped_data.get(rec.id, 0)
 
-    @api.depends("event_ids")
+    @api.depends()
     def _compute_event_count(self):
         mapped_data = read_counts_for_o2m(
             records=self, field_name="event_ids", sudo=True
@@ -95,7 +95,7 @@ class DarkRabbitConnection(models.Model):
         for rec in self:
             rec.outgoing_route_count = mapped_data.get(rec.id, 0)
 
-    @api.depends("outgoing_event_ids")
+    @api.depends()
     def _compute_outgoing_event_count(self):
         mapped_data = read_counts_for_o2m(
             records=self, field_name="outgoing_event_ids", sudo=True

--- a/dark_rabbit/models/queue.py
+++ b/dark_rabbit/models/queue.py
@@ -55,7 +55,7 @@ class DarkRabbitQueue(models.Model):
 
     active = fields.Boolean(default=True, index=True)
 
-    @api.depends("event_ids")
+    @api.depends()
     def _compute_event_count(self):
         mapped_data = read_counts_for_o2m(
             records=self, field_name="event_ids", sudo=True


### PR DESCRIPTION
For some reason, Odoo sometimes may optimize and fetch field dependencies, thus full `event_ids` or `outgoing_event_ids` data, that could contain millions of records